### PR TITLE
Add testing for server error UI display

### DIFF
--- a/cypress/e2e/error-handling.cy.js
+++ b/cypress/e2e/error-handling.cy.js
@@ -1,0 +1,17 @@
+describe('Tests for network request errors', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
+      statusCode: 500
+    });
+    cy.visit('http://localhost:3000')
+  });
+
+  it('Should display a header with the title of the app', () => {
+    cy.get('h1').should('have.text', 'Rancid Tomatillos');
+  });
+
+  it('Should render an error message if the network request sent on initial page load returns a 5xx server error', () => {
+    cy.get('.error-title').contains('h2', 'Something\'s gone wrong.')
+      .get('.error-detail').should('have.text', 'There was an unexpected issue with the server. Please try again later.');
+  });
+});


### PR DESCRIPTION
# PR Template

### Types of changes made?

- [x]  testing
- [ ]  documentation
- [ ]  javascript
- [ ]  functionality
- [ ]  refactor

### What does this PR do? Describe your changes:

- Writes test for the error message view, rendered when a 500-level server error occurs. All tests are passing.

### Relevant Tickets?

- Completes the last tasks for [Cypress testing](https://github.com/Adam-Meza/rancid-tomatillos/issues/9)

### Questions/Comments/Relevant Screenshots?

