### PR TITLE
[Feature] NotFound component for bad URLs

### DIFF
--- a/cypress/e2e/not-found.cy.js
+++ b/cypress/e2e/not-found.cy.js
@@ -1,0 +1,28 @@
+import movies from './movies-test-data.js';
+
+describe('Tests for bad URLs', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
+      statusCode: 200,
+      body: {
+        movies: movies
+      }
+    });
+    cy.visit('http://localhost:3000/movies')
+  });
+
+  it('Should display a header with the title of the app', () => {
+    cy.get('h1').should('have.text', 'Rancid Tomatillos');
+  });
+
+  it('Should render an error message if the user goes to a path that doesn\'t exist', () => {
+    cy.get('.error-title').contains('h2', 'This page doesn\'t exist.')
+      .get('.error-detail').contains('a', 'Go back to Home').should('have.attr', 'href')
+  });
+
+  it('Should should take the user back to all movies view after clicking the displayed link', () => {
+    cy.get('.error-detail').contains('Home').click()
+      .url().should('eq', 'http://localhost:3000/')
+      .get('.movie-container').children().should('have.length', 6);
+  });
+});

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,14 @@
-import './Components/Movie/Movie.js'
-import Header from './Components/Header/Header.js'
-import MovieDetails from './Components/MovieDetails/MovieDetails.js'
-import './Components/MovieContainer/MovieContainer.js'
-import ErrorMessage from './Components/ErrorMessage/ErrorMessage.js'
+import './Components/Movie/Movie.js';
+import Header from './Components/Header/Header.js';
+import MovieDetails from './Components/MovieDetails/MovieDetails.js';
+import './Components/MovieContainer/MovieContainer.js';
+import ErrorMessage from './Components/ErrorMessage/ErrorMessage.js';
+import NotFound from './Components/NotFound/NotFound.js';
 import './App.css';
 import React, { Component } from 'react';
 import MovieContainer from './Components/MovieContainer/MovieContainer.js';
 import { cleanAllMoviesData}  from './utilities.js';
-import { Route, Switch } from 'react-router-dom/cjs/react-router-dom.min.js'
-
+import { Route, Switch } from 'react-router-dom/cjs/react-router-dom.min.js';
 
 class App extends Component {
   constructor() {
@@ -47,6 +47,7 @@ class App extends Component {
           {/* <Route exact path='/error' render={() => <ErrorMessage error={this.state.error} />} /> */}
           <Route exact path='/movies/:id' component={MovieDetails} />
           <Route exact path='/' render={() => <MovieContainer movies={this.state.movies} />} />
+          <Route path="*" component={NotFound} />
         </Switch>
       </main>
     )

--- a/src/Components/NotFound/NotFound.js
+++ b/src/Components/NotFound/NotFound.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import '../ErrorMessage/ErrorMessage.css';
+
+function NotFound() {
+  return (
+    <div className='error-message-wrapper'>
+      <div className='error-message'>
+        <h2 className="error-title">This page doesn't exist.</h2>
+        <NavLink to='/' className="error-detail">Go back to Home</NavLink>
+      </div>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
# PR Template

### Types of changes made?

- [x]  testing
- [ ]  documentation
- [ ]  javascript
- [x]  functionality
- [ ]  refactor

### What does this PR do? Describe your changes:

- Adds functionality: Added `NotFound` component to a new directory. Added an additional Route to App's render method, to direct the user to a specific 'Not Found' page when they go to a URL path that doesn't exist. 

- Writes test for: Added testing for this component, including asserting the URL path and user flow when the 'Go back to Home' link is clicked.

### Relevant Tickets?

- Additional work for React Routing implementation and ticket https://github.com/Adam-Meza/rancid-tomatillos/issues/9

### Questions/Comments/Relevant Screenshots?

All CSS for this component is currently using the `ErrorMessage.css` file and selectors. This made sense for display consistency and reducing CSS redundancy. If the ErrorMessage component or styling is changed, we will likely need to edit `NotFound` as well. I will keep an eye on future PRs any changes.

